### PR TITLE
item-structure: Ported over the items from the item matrix.

### DIFF
--- a/assets/items.json
+++ b/assets/items.json
@@ -1,0 +1,492 @@
+{
+  "0": {
+    "id": 0,
+    "name": "Exit Door (Closed)",
+    "spriteId": 0,
+    "inventorySpriteId": 0,
+    "descriptions": [
+      "You shall not pass!"
+    ],
+    "combinations": {
+      "29": {
+        "text": [
+          "You placed the bucket on the floor next to the door."
+        ]
+      }
+    }
+  },
+  "1": {
+    "id": 1,
+    "name": "Exit Door (Opening)",
+    "spriteId": 1,
+    "inventorySpriteId": 1,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "2": {
+    "id": 2,
+    "name": "Exit Door (Open)",
+    "spriteId": 2,
+    "inventorySpriteId": 2,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "3": {
+    "id": 3,
+    "name": "Porthole",
+    "spriteId": 3,
+    "inventorySpriteId": 0,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "25": {
+        "text": [
+          "[you dumped out the sick from the bucket... hopefully there was nobody standing underneath...]"
+        ],
+        "newItemId": 26
+      }
+    }
+  },
+  "4": {
+    "id": 4,
+    "name": "Bed",
+    "spriteId": 4,
+    "inventorySpriteId": 4,
+    "descriptions": [
+      "There's no going back.", "Don't be such a lazy shit."
+    ],
+    "combinations": {}
+  },
+  "5": {
+    "id": 5,
+    "name": "Bed Lamp (On, Plugged In)",
+    "spriteId": 5,
+    "inventorySpriteId": 5,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "6": {
+    "id": 6,
+    "name": "Bed Lamp (Off, Unplugged)",
+    "spriteId": 6,
+    "inventorySpriteId": 6,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "7": {
+    "id": 7,
+    "name": "Wall Socket (Bed Lamp Plugged In)",
+    "spriteId": 7,
+    "inventorySpriteId": 7,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "8": {
+    "id": 8,
+    "name": "Wall Socket (Nothing Plugged In)",
+    "spriteId": 8,
+    "inventorySpriteId": 8,
+    "descriptions": [
+      "What did you think that was gonna do?", "Don't stick your finger in there!"
+    ],
+    "combinations": {
+      "29": {
+        "text": [
+          ".... BOOOOOOM!!!!"
+        ]
+      }
+    }
+  },
+  "9": {
+    "id": 9,
+    "name": "Wall Socket (Bucket Plugged In)",
+    "spriteId": 9,
+    "inventorySpriteId": 9,
+    "descriptions": [
+      "That's a-doorable!", "When one door closes, that one opens.", "You seem a little unhinged.",
+      "You knock knock knocked that out of the park.", "Just go through the door, idiot."
+    ],
+    "combinations": {}
+  },
+  "10": {
+    "id": 10,
+    "name": "Mini Bar (External)",
+    "spriteId": 10,
+    "inventorySpriteId": 10,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "11": {
+    "id": 11,
+    "name": "Alcohol Bottle",
+    "spriteId": 11,
+    "inventorySpriteId": 11,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "0": {
+        "text": [
+          "Alcohol is the key to happiness. Not this door."
+        ]
+      },
+      "3": {
+        "text": [
+          "That's a waste of good booze."
+        ]
+      },
+      "26": {
+        "newItemId": 28
+      },
+      "27": {
+        "newItemId": 29
+      }
+    }
+  },
+  "12": {
+    "id": 12,
+    "name": "Mini Bar Nuts",
+    "spriteId": 12,
+    "inventorySpriteId": 12,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "0": {
+        "text": [
+          "Nuthing happened.", "That's nut going to help.", "Don't put your nuts all over the door."
+        ]
+      },
+      "3": {
+        "text": [
+          "That's a waste of good nuts."
+        ]
+      },
+      "30": {
+        "text": [
+          "[...the parrot seems willing to talk...]"
+        ]
+      }
+    }
+  },
+  "13": {
+    "id": 13,
+    "name": "Lava Lamp (Plugged In On Table)",
+    "spriteId": 13,
+    "inventorySpriteId": 13,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "26": {
+        "newItemId": 27
+      },
+      "28": {
+        "newItemId": 29
+      }
+    }
+  },
+  "14": {
+    "id": 14,
+    "name": "Lava Lamp (Unplugged)",
+    "spriteId": 14,
+    "inventorySpriteId": 14,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "1": {
+        "text": [
+          "I lava the way you're thinking. But you're wrong."
+        ]
+      },
+      "3": {
+        "text": [
+          "I lava the way you're thinking. But you're wrong."
+        ]
+      },
+      "7": {
+        "text": [
+          "Something's already plugged in, genius."
+        ]
+      },
+      "8": {
+        "newItemId": 9
+      },
+      "26": {
+        "newItemId": 27
+      },
+      "28": {
+        "newItemId": 29
+      }
+    }
+  },
+  "15": {
+    "id": 15,
+    "name": "Wardrobe (Closed, Noises)",
+    "spriteId": 15,
+    "inventorySpriteId": 15,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "16": {
+    "id": 16,
+    "name": "Wardrobe (Opening)",
+    "spriteId": 16,
+    "inventorySpriteId": 16,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "17": {
+    "id": 17,
+    "name": "Wardrobe (Open)",
+    "spriteId": 17,
+    "inventorySpriteId": 17,
+    "descriptions": [
+      "I can confirm this doesn't lead to Narnia."
+    ],
+    "combinations": {}
+  },
+  "18": {
+    "id": 18,
+    "name": "Torch",
+    "spriteId": 18,
+    "inventorySpriteId": 18,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "2": {
+        "text": [
+          "That's a-doorable!", "When one door closes, that one opens.", "You seem a little unhinged.",
+          "You knock knock knocked that out of the park."
+        ]
+      },
+      "3": {
+        "text": [
+          "It's daytime. Use your eyes. Moron."
+        ]
+      }
+    }
+  },
+  "19": {
+    "id": 19,
+    "name": "Lighter",
+    "spriteId": 19,
+    "inventorySpriteId": 19,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "0": {
+        "text": [
+          "You flaming idiot."
+        ]
+      },
+      "2": {
+        "text": [
+          "That's a-doorable!", "When one door closes, that one opens.", "You seem a little unhinged.",
+          "You knock knock knocked that out of the park."
+        ]
+      },
+      "3": {
+        "text": [
+          "It's not raining. You can't set fire to anything right now."
+        ]
+      }
+    }
+  },
+  "20": {
+    "id": 20,
+    "name": "GameBae",
+    "spriteId": 20,
+    "inventorySpriteId": 20,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "0": {
+        "text": [
+          "The princess is in another castle"
+        ]
+      },
+      "2": {
+        "text": [
+          "That's a-doorable!", "When one door closes, that one opens.", "You seem a little unhinged.",
+          "You knock knock knocked that out of the park."
+        ]
+      },
+      "3": {
+        "text": [
+          "Why..?", "Keep that, it'll be a collectible someday."
+        ]
+      }
+    }
+  },
+  "21": {
+    "id": 21,
+    "name": "Parrot Chair (Empty of Parrot)",
+    "spriteId": 21,
+    "inventorySpriteId": 21,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "22": {
+    "id": 22,
+    "name": "Parrot Chair (Full of Parrot)",
+    "spriteId": 22,
+    "inventorySpriteId": 22,
+    "descriptions": [
+      "Keep your fingers to yourself!", "Get back to the mission.", "Keep your eyes on the prize!",
+      "I am not the prize."
+    ],
+    "combinations": {}
+  },
+  "23": {
+    "id": 23,
+    "name": "Party Flyer (On Table)",
+    "spriteId": 23,
+    "inventorySpriteId": 23,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {}
+  },
+  "24": {
+    "id": 24,
+    "name": "Poster(s)",
+    "spriteId": 24,
+    "inventorySpriteId": 24,
+    "descriptions": [
+      "TBC when we know what the posters are"
+    ],
+    "combinations": {}
+  },
+  "25": {
+    "id": 25,
+    "name": "Sick Bucket (Initially full of sick)",
+    "spriteId": 25,
+    "inventorySpriteId": 25,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "0": {
+        "text": [
+          "That's pretty sick.", "Why would you do that?"
+        ]
+      },
+      "3": {
+        "newItemId": 26
+      }
+    }
+  },
+  "26": {
+    "id": 26,
+    "name": "Sick Bucket (Empty)",
+    "spriteId": 26,
+    "inventorySpriteId": 26,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "0": {
+        "text": [
+          "This is a sick place for a bucket."
+        ]
+      },
+      "11": {
+        "newItemId": 28
+      },
+      "13": {
+        "newItemId": 27
+      },
+      "14": {
+        "newItemId": 27
+      }
+    }
+  },
+  "27": {
+    "id": 27,
+    "name": "Sick Bucket (With Lava Lamp)",
+    "spriteId": 27,
+    "inventorySpriteId": 27,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "11": {
+        "newItemId": 29
+      }
+    }
+  },
+  "28": {
+    "id": 28,
+    "name": "Sick Bucket (With Alcohol)",
+    "spriteId": 28,
+    "inventorySpriteId": 28,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "13": {
+        "newItemId": 29
+      },
+      "14": {
+        "newItemId": 29
+      }
+    }
+  },
+  "29": {
+    "id": 29,
+    "name": "Sick Bucket (With Lava Lamp and Alcohol)",
+    "spriteId": 29,
+    "inventorySpriteId": 29,
+    "descriptions": [
+      ""
+    ],
+    "combinations": {
+      "8": {
+        "text": [
+          "You can feel the heat radiating off, its about to explode."
+        ]
+      }
+    }
+  },
+  "30": {
+    "id": 30,
+    "name": "Parrot",
+    "spriteId": 30,
+    "inventorySpriteId": 30,
+    "descriptions": [
+      "Keep your fingers to yourself!", "Get back to the mission.", "Keep your eyes on the prize!",
+      "I am not the prize."
+    ],
+    "combinations": {
+      "12": {
+        "text": [
+          "[...the parrot starts talking...]"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #6 

## Description

The items have the correct relations with the combinations, along with their descriptions.
The item `id`, `spriteId`, and `inventorySpriteId` are currently incremented by 1 for each of the items, however this might change based on the implementation of the asset loader.

## Does this PR introduce a breaking change? 

- [ ] Yes
- [x] No
